### PR TITLE
Update Database.php

### DIFF
--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -248,7 +248,7 @@ class Database implements ConnectionInterface {
      *
      * @throws \Exception
      */
-    public function transaction( Closure $callback ) {
+    public function transaction( \Closure $callback ) {
         // TODO: Implement transaction() method.
     }
 

--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -295,7 +295,7 @@ class Database implements ConnectionInterface {
      *
      * @return array
      */
-    public function pretend( Closure $callback ) {
+    public function pretend( \Closure $callback ) {
         // TODO: Implement pretend() method.
     }
 


### PR DESCRIPTION
FIX an issue seen on PHP7 (Declaration of WeDevs\ORM\Eloquent\Database::transaction(WeDevs\ORM\Eloquent\Closure $callback) must be compatible with Illuminate\Database\ConnectionInterface::transaction(Closure $callback))
