### PR TITLE
Fixed database transaction

### DIFF
--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -320,7 +320,7 @@ class Database implements ConnectionInterface
     public function beginTransaction()
     {
         $transaction = $this->unprepared("START TRANSACTION;");
-        if ($transaction) {
+        if (false !== $transaction) {
             $this->transactionCount++;
         }
     }
@@ -336,7 +336,7 @@ class Database implements ConnectionInterface
             return;
         }
         $transaction = $this->unprepared("COMMIT;");
-        if ($transaction) {
+        if (false !== $transaction) {
             $this->transactionCount--;
         }
     }
@@ -352,7 +352,7 @@ class Database implements ConnectionInterface
             return;
         }
         $transaction = $this->unprepared("ROLLBACK;");
-        if ($transaction) {
+        if (false !== $transaction) {
             $this->transactionCount--;
         }
     }


### PR DESCRIPTION
#36 According to the original [documentation](https://codex.wordpress.org/Class_Reference/wpdb#General_Syntax) the query method is returned 0 when any of rows weren't affected but it's not an error. For transaction need to use "false !== $result" condition