### PR TITLE
Add query method to the Database connection class

### DIFF
--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -97,6 +97,18 @@ class Database implements ConnectionInterface
         return new Expression($value);
     }
 
+	/**
+	 * Get a new query builder instance.
+	 *
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+	public function query()
+	{
+		return new Builder(
+			$this, $this->getQueryGrammar(), $this->getPostProcessor()
+		);
+	}
+
     /**
      * Run a select statement and return a single result.
      *


### PR DESCRIPTION
To return \Illuminate\Database\Query\Builder object. 

Resolves https://github.com/tareq1988/wp-eloquent/issues/52