### PR TITLE
Code style changes and fix join clauses not auto prefixing table names

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WeDevs\ORM\Eloquent;
 
 use Illuminate\Database\Query\Builder as EloquentBuilder;
@@ -28,5 +29,4 @@ class Builder extends EloquentBuilder {
 
         return $this;
     }
-
 }

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -3,6 +3,7 @@
 namespace WeDevs\ORM\Eloquent;
 
 use Illuminate\Database\Query\Builder as EloquentBuilder;
+use Illuminate\Database\Query\JoinClause;
 
 /**
  * QueryBuilder Class
@@ -11,7 +12,52 @@ use Illuminate\Database\Query\Builder as EloquentBuilder;
  */
 class Builder extends EloquentBuilder {
 
-    /**
+	/**
+	 * The database connection instance.
+	 *
+	 * @var \WeDevs\ORM\Eloquent\Database;
+	 */
+	public $connection;
+
+	/**
+	 * Add a join clause to the query.
+	 *
+	 * @param string      $table
+	 * @param string      $first
+	 * @param string|null $operator
+	 * @param string|null $second
+	 * @param string      $type
+	 * @param bool        $where
+	 *
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+	public function join($table, $first, $operator = null, $second = null, $type = 'inner', $where = false)
+	{
+		return parent::join($this->getConnection()->getTableName($table), $first, $operator, $second, $type, $where);
+	}
+
+	/**
+	 * Add a "cross join" clause to the query.
+	 *
+	 * @param string      $table
+	 * @param string|null $first
+	 * @param string|null $operator
+	 * @param string|null $second
+	 *
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+	public function crossJoin($table, $first = null, $operator = null, $second = null)
+	{
+		if ($first) {
+			return $this->join($table, $first, $operator, $second, 'cross');
+		}
+
+		$this->joins[] = new JoinClause($this, 'cross', $this->getConnection()->getTableName($table));
+
+		return $this;
+	}
+
+	/**
      * Add an exists clause to the query.
      *
      * @param  \Illuminate\Database\Query\Builder $query
@@ -29,4 +75,14 @@ class Builder extends EloquentBuilder {
 
         return $this;
     }
+
+	/**
+	 * Get the database connection instance.
+	 *
+	 * @return \WeDevs\ORM\Eloquent\Database
+	 */
+	public function getConnection()
+	{
+		return $this->connection;
+	}
 }

--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Arr;
 
 class Database implements ConnectionInterface
 {
-
     public $db;
 
     /**

--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -123,8 +123,9 @@ class Database implements ConnectionInterface
 
         $result = $this->db->get_row($query);
 
-        if ($result === false || $this->db->last_error)
-            throw new QueryException($query, $bindings, new \Exception($this->db->last_error));
+        if ($result === false || $this->db->last_error) {
+	        throw new QueryException($query, $bindings, new \Exception($this->db->last_error));
+        }
 
         return $result;
     }
@@ -145,8 +146,9 @@ class Database implements ConnectionInterface
 
         $result = $this->db->get_results($query);
 
-        if ($result === false || $this->db->last_error)
-            throw new QueryException($query, $bindings, new \Exception($this->db->last_error));
+        if ($result === false || $this->db->last_error) {
+	        throw new QueryException($query, $bindings, new \Exception($this->db->last_error));
+        }
 
         return $result;
     }
@@ -214,8 +216,9 @@ class Database implements ConnectionInterface
 
         $result = $this->db->query($new_query);
 
-        if ($result === false || $this->db->last_error)
-            throw new QueryException($new_query, $bindings, new \Exception($this->db->last_error));
+        if ($result === false || $this->db->last_error) {
+	        throw new QueryException($new_query, $bindings, new \Exception($this->db->last_error));
+        }
 
         return (array) $result;
     }
@@ -482,7 +485,7 @@ class Database implements ConnectionInterface
 	 * @param  string  $table
 	 * @return string
 	 */
-    protected function getTableName(string $table)
+    public function getTableName(string $table)
     {
     	return $this->db->prefix . $table;
     }

--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -53,6 +53,7 @@ class Database implements ConnectionInterface
         $this->config = [
             'name' => 'wp-eloquent-mysql2',
         ];
+
         $this->db = $wpdb;
     }
 
@@ -77,11 +78,9 @@ class Database implements ConnectionInterface
     {
         $processor = $this->getPostProcessor();
 
-        $table = $this->db->prefix . $table;
-
         $query = new Builder($this, $this->getQueryGrammar(), $processor);
 
-        return $query->from($table);
+        return $query->from($this->getTableName($table));
     }
 
     /**
@@ -351,6 +350,7 @@ class Database implements ConnectionInterface
     public function transaction(\Closure $callback, $attempts = 1)
     {
         $this->beginTransaction();
+
         try {
             $data = $callback();
             $this->commit();
@@ -369,6 +369,7 @@ class Database implements ConnectionInterface
     public function beginTransaction()
     {
         $transaction = $this->unprepared("START TRANSACTION;");
+
         if (false !== $transaction) {
             $this->transactionCount++;
         }
@@ -384,7 +385,9 @@ class Database implements ConnectionInterface
         if ($this->transactionCount < 1) {
             return;
         }
+
         $transaction = $this->unprepared("COMMIT;");
+
         if (false !== $transaction) {
             $this->transactionCount--;
         }
@@ -400,7 +403,9 @@ class Database implements ConnectionInterface
         if ($this->transactionCount < 1) {
             return;
         }
+
         $transaction = $this->unprepared("ROLLBACK;");
+
         if (false !== $transaction) {
             $this->transactionCount--;
         }
@@ -469,5 +474,16 @@ class Database implements ConnectionInterface
     public function getConfig($option = null)
     {
         return Arr::get($this->config, $option);
+    }
+
+	/**
+	 * Get the prefixed table name.
+	 *
+	 * @param  string  $table
+	 * @return string
+	 */
+    protected function getTableName(string $table)
+    {
+    	return $this->db->prefix . $table;
     }
 }

--- a/src/Eloquent/Database.php
+++ b/src/Eloquent/Database.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WeDevs\ORM\Eloquent;
 
 use Illuminate\Database\ConnectionInterface;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -44,7 +44,7 @@ abstract class Model extends Eloquent {
 
         $table = str_replace( '\\', '', snake_case( str_plural( class_basename( $this ) ) ) );
 
-        return $this->getConnection()->db->prefix . $table ;
+        return $this->getConnection()->getTableName($table);
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WeDevs\ORM\Eloquent;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -22,7 +22,7 @@ abstract class Model extends Eloquent {
     /**
      * Get the database connection for the model.
      *
-     * @return \Illuminate\Database\Connection
+     * @return \WeDevs\ORM\Eloquent\Database
      */
     public function getConnection() {
         return Database::instance();
@@ -52,7 +52,6 @@ abstract class Model extends Eloquent {
      * @return \Illuminate\Database\Query\Builder
      */
     protected function newBaseQueryBuilder() {
-
         $connection = $this->getConnection();
 
         return new Builder(

--- a/src/Eloquent/Resolver.php
+++ b/src/Eloquent/Resolver.php
@@ -11,7 +11,7 @@ class Resolver implements ConnectionResolverInterface {
      *
      * @param  string $name
      *
-     * @return \Illuminate\Database\Connection
+     * @return \WeDevs\ORM\Eloquent\Database
      */
     public function connection( $name = null ) {
         return Database::instance();

--- a/src/Eloquent/Resolver.php
+++ b/src/Eloquent/Resolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WeDevs\ORM\Eloquent;
 
 use Illuminate\Database\ConnectionResolverInterface;

--- a/src/WP/Comment.php
+++ b/src/WP/Comment.php
@@ -2,7 +2,6 @@
 
 namespace WeDevs\ORM\WP;
 
-
 use WeDevs\ORM\Eloquent\Model;
 
 class Comment extends Model

--- a/src/WP/Post.php
+++ b/src/WP/Post.php
@@ -2,7 +2,6 @@
 
 namespace WeDevs\ORM\WP;
 
-
 use WeDevs\ORM\Eloquent\Model;
 
 /**

--- a/src/WP/PostMeta.php
+++ b/src/WP/PostMeta.php
@@ -12,6 +12,6 @@ class PostMeta extends Model
 
     public function getTable()
     {
-        return $this->getConnection()->db->prefix . 'postmeta';
+        return $this->getConnection()->getTableName('postmeta');
     }
 }

--- a/src/WP/PostMeta.php
+++ b/src/WP/PostMeta.php
@@ -2,7 +2,6 @@
 
 namespace WeDevs\ORM\WP;
 
-
 use WeDevs\ORM\Eloquent\Model;
 
 class PostMeta extends Model

--- a/src/WP/User.php
+++ b/src/WP/User.php
@@ -2,7 +2,6 @@
 
 namespace WeDevs\ORM\WP;
 
-
 use WeDevs\ORM\Eloquent\Model;
 
 class User extends Model

--- a/src/WP/UserMeta.php
+++ b/src/WP/UserMeta.php
@@ -2,7 +2,6 @@
 
 namespace WeDevs\ORM\WP;
 
-
 use WeDevs\ORM\Eloquent\Model;
 
 class UserMeta extends Model

--- a/src/WP/UserMeta.php
+++ b/src/WP/UserMeta.php
@@ -12,6 +12,6 @@ class UserMeta extends Model
 
     public function getTable()
     {
-        return $this->getConnection()->db->prefix . 'usermeta';
+        return $this->getConnection()->getTableName('usermeta');
     }
 }


### PR DESCRIPTION
After using this package inside of a WordPress plugin, I ran into an issue where the various join() methods did not auto prefix the table names. 

I've added a new method to the Database class that will automatically prefix the table name, and replaced all usages of the $db property to use this new method instead. It is public so that it can be accessed inside of the Builder class, and Model classes.