### PR TITLE
Fix prefix missing is table variable is setup

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
  */
 abstract class Model extends Eloquent {
 
+    protected $db_prefix;
+
     /**
      * @param array $attributes
      */
@@ -17,6 +19,8 @@ abstract class Model extends Eloquent {
         static::$resolver = new Resolver();
 
         parent::__construct( $attributes );
+
+        $this->db_prefix = $this->getConnection()->db->prefix;
     }
 
     /**
@@ -38,12 +42,12 @@ abstract class Model extends Eloquent {
      */
     public function getTable() {
         if ( isset( $this->table ) ) {
-            return $this->table;
+            return $this->db_prefix . $this->table;
         }
 
         $table = str_replace( '\\', '', snake_case( str_plural( class_basename( $this ) ) ) );
 
-        return $this->getConnection()->db->prefix . $table ;
+        return $this->db_prefix . $table ;
     }
 
     /**


### PR DESCRIPTION
In my case I wanted a specific model extended from your ```Post```model.  
You derivate the table name based on the class name. If I create ```MyPost``` you are looking for a ```my_post``` table, add the prefix which is fine but was not appropriated in my case.  
When I set up a table property it crashes because you forgot to take consideration of the prefix in that case.

This PR fixes this.